### PR TITLE
Revert "ARM64: Sdm670-gpu (Underclock Gpu to 160mhz)"

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm670-gpu.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm670-gpu.dtsi
@@ -570,10 +570,10 @@
 				/* MIN SVS */
 				qcom,gpu-pwrlevel@4 {
 					reg = <4>;
-					qcom,gpu-freq = <160000000>;
-					qcom,bus-freq = <3>;
-					qcom,bus-min = <2>;
-					qcom,bus-max = <3>;
+					qcom,gpu-freq = <180000000>;
+					qcom,bus-freq = <4>;
+					qcom,bus-min = <3>;
+					qcom,bus-max = <4>;
 				};
 
 				/* XO */

--- a/drivers/clk/qcom/gpucc-sdm845.c
+++ b/drivers/clk/qcom/gpucc-sdm845.c
@@ -286,7 +286,7 @@ static const struct freq_tbl  ftbl_gpu_cc_gx_gfx3d_clk_src_sdm845_v2[] = {
 };
 
 static const struct freq_tbl ftbl_gpu_cc_gx_gfx3d_clk_src_sdm670[] = {
-	F(160000000, P_CRC_DIV,  1, 0, 0),
+	F(180000000, P_CRC_DIV,  1, 0, 0),
 	F(267000000, P_CRC_DIV,  1, 0, 0),
 	F(355000000, P_CRC_DIV,  1, 0, 0),
 	F(430000000, P_CRC_DIV,  1, 0, 0),
@@ -646,7 +646,7 @@ static void gpu_cc_gfx_sdm845_fixup_sdm670(void)
 {
 	gpu_cc_gx_gfx3d_clk_src.freq_tbl =
 				ftbl_gpu_cc_gx_gfx3d_clk_src_sdm670;
-	gpu_cc_gx_gfx3d_clk_src.clkr.hw.init->rate_max[VDD_GX_MIN] = 160000000;
+	gpu_cc_gx_gfx3d_clk_src.clkr.hw.init->rate_max[VDD_GX_MIN] = 180000000;
 	gpu_cc_gx_gfx3d_clk_src.clkr.hw.init->rate_max[VDD_GX_LOWER] =
 		267000000;
 	gpu_cc_gx_gfx3d_clk_src.clkr.hw.init->rate_max[VDD_GX_LOW] = 355000000;


### PR DESCRIPTION
This reverts commit e9c3ebe9694e4b5b65129fa8507de16d989a7e4c.